### PR TITLE
Issue/29 MongoDBの準備とそのサンプル

### DIFF
--- a/jumbot_reaction.js
+++ b/jumbot_reaction.js
@@ -6,7 +6,8 @@ const reactions = [
     require('./reaction/middle_finger'),
     require('./reaction/eggplant'),
     require('./reaction/sord_master'),
-    require('./reaction/commander')
+    require('./reaction/commander'),
+    require('./reaction/achievement')
 ]
 
 exports.run = function (client, message) {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     },
     "dependencies": {
         "discord.js": "11.3.0",
+        "mongodb": "^3.0.2",
         "request": "2.83.0"
     }
 }

--- a/reaction/achievement.js
+++ b/reaction/achievement.js
@@ -22,8 +22,8 @@ exports.run = function (client, message) {
         (async function() {
             let mongo_client = null;
             try {
-                const client = mongo_client = await MongoClient.connect(process.env.MONGODB_URI);
-                let db = client.db(DB_NAME);
+                mongo_client = await MongoClient.connect(process.env.MONGODB_URI);
+                let db = mongo_client.db(DB_NAME);
                 const users = await db.collection("users");
                 let word;
                 if(delta > 0) {

--- a/reaction/achievement.js
+++ b/reaction/achievement.js
@@ -1,0 +1,56 @@
+const mongodb = require('mongodb')
+const MongoClient = mongodb.MongoClient
+const MONGODB_URI = process.env.MONGODB_URI
+const __SPLIT_URI = MONGODB_URI.split('/')
+const DB_NAME = __SPLIT_URI[__SPLIT_URI.length-1]
+
+// Commander.
+exports.isTarget = function (message) {
+    return /([^-+]+)(\+\+|\-\-)/.test(message.content);
+}
+
+exports.run = function (client, message) {
+    var result = message.content.match(/([^-+]+)(\+\+|\-\-)/);
+    if(!result) { return; }
+
+    let name = result[1];
+    let operator = result[2];
+    let delta = operator === '++' ? 1 : -1;
+
+    let user = client.users.find('username', name);
+    if(user) {
+        (async function() {
+            let mongo_client = null;
+            try {
+                const client = mongo_client = await MongoClient.connect(process.env.MONGODB_URI);
+                let db = client.db(DB_NAME);
+                const users = await db.collection("users");
+                let word;
+                if(delta > 0) {
+                    word = 'いいぞ';
+                } else if(Math.floor(Math.random(9)*10) == 0) {
+                    // 10%でおまけします
+                    delta = 1;
+                    word = 'たまには　おまけしてあげるね くじけちゃだめだよ。';
+                } else {
+                    word = 'もっと　がんばらないと　だめだぞ。';
+                }
+
+                await users.updateOne( { id: user.id }, {$inc:{achievement:delta}}, {upsert: true});
+                const updated_user = await users.findOne({ id: user.id });
+                message.channel.send(word + ' (' + name + ':通算' + updated_user.achievement + ')');
+                mongo_client.close();
+            } catch (err) {
+                if(mongo_client) {
+                    mongo_client.close();
+                }
+                console.log(err);
+                message.channel.send('ばぐってるぞ');  
+            }
+        })();
+    } else {
+        message.channel.send(name + 'はいないぞ');
+    }
+}
+
+process.on('unhandledRejection', console.dir);


### PR DESCRIPTION
close: #29 

## 概要
アカウント名に++、または--をつけることで、実績値をカウントするようにします。
mongodbに記録されるようになります。

## 導入手順
1. HerokuのAccountsでクレジットカード情報を登録します。
1. HerokuのPersonal > (アプリ名) > Resources > Add-Onsで mLab MongoDBを追加します。

上記手順を踏むと、勝手に環境変数に「MONGODB_URI」が追加されているはず。

## 検証手順
任意のチャネルで アカウント名に++、または--をつけて投稿します。
e,g.) vourja++ 
e.g.) いちろこ--

アカウント毎の成果を通算で教えてくれます。
また、10%の確率で--しても++になります。